### PR TITLE
Fixed README.md how to apply patches to firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,19 @@ If you device is not responding anymore, you have to apply DFU procedure to unbr
    git apply ../patches/fw.diff
    
    cd hdl
-   git apply ../../hdl.diff
+   git apply ../../patches/hdl.diff
    cd ..
    
    cd linux
-   git apply ../../linux.diff
+   git apply ../../patches/linux.diff
    cd ..
    
    cd u-boot-xlnx
-   git apply ../../u-boot-xlnx.diff
+   git apply ../../patches/u-boot-xlnx.diff
+   cd ..
+
+   cd buildroot
+   git apply ../../patches/buildroot.diff
    cd ..
    
    ```


### PR DESCRIPTION
The current README.md is missing the subdirectory 'patches' in the instructions.
The given instruction would not work when copy-pasted. This is corrected.

Also, the buildroot patch was not mentioned in the instructions, while there is a patch available.
Therefore the instruction is appended with buildroot patch.